### PR TITLE
Add new issues to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,5 @@ CP-8 will:
 ```ruby
 /payload?config[stale_issue_weeks]=6 # Set stale issue cutoff to 6 weeks
 /payload?config[review_channel]=reviews # Send review requests/updates to specified Slack channel
+/payload?config[project_column_id]=49 # Automatically add new issues to a project column
 ```

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,8 +1,9 @@
 class Configuration
-  attr_reader :stale_issue_weeks, :review_channel
+  attr_reader :stale_issue_weeks, :review_channel, :project_column_id
 
-  def initialize(stale_issue_weeks: nil, review_channel: nil)
+  def initialize(stale_issue_weeks: nil, review_channel: nil, project_column_id: nil)
     @stale_issue_weeks = stale_issue_weeks
     @review_channel = review_channel
+    @project_column_id = project_column_id
   end
 end

--- a/lib/issue.rb
+++ b/lib/issue.rb
@@ -5,9 +5,10 @@ class Issue
   WIP_TAG = "WIP"
   SMALL_PR_ADDITION_LIMIT = 100
 
-  attr_reader :number, :html_url, :repo, :title
+  attr_reader :id, :number, :html_url, :repo, :title
 
-  def initialize(number:, repo:, title: nil, state: nil, html_url: nil, user: nil, **other)
+  def initialize(id:, number:, repo:, title: nil, state: nil, html_url: nil, user: nil, **other)
+    @id = id
     @title = title
     @state = state
     @number = number

--- a/lib/payload.rb
+++ b/lib/payload.rb
@@ -42,12 +42,8 @@ class Payload
     action.submitted? && review&.decisive?
   end
 
-  def opened_action?
-    action.opened?
-  end
-
   def opened_new_issue?
-    opened_action? && issue_action?
+    action.opened? && issue_action?
   end
 
   def issue_action?

--- a/lib/payload.rb
+++ b/lib/payload.rb
@@ -42,6 +42,10 @@ class Payload
     action.submitted? && review&.decisive?
   end
 
+  def opened_action?
+    action.opened?
+  end
+
   def pull_request_action?
     data[:pull_request].present?
   end

--- a/lib/payload.rb
+++ b/lib/payload.rb
@@ -46,6 +46,14 @@ class Payload
     action.opened?
   end
 
+  def opened_new_issue?
+    opened_action? && issue_action?
+  end
+
+  def issue_action?
+    !pull_request_action?
+  end
+
   def pull_request_action?
     data[:pull_request].present?
   end

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -74,7 +74,7 @@ class Processor
     end
 
     def move_new_issue_to_project
-      return unless payload.opened_action?
+      return unless payload.opened_action? && !payload.pull_request_action?
 
       log "Moving new issues to project"
       ProjectManager.new(issue: payload.issue, project_column_id: config.project_column_id).run

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -74,10 +74,10 @@ class Processor
     end
 
     def move_new_issue_to_project
-      return unless payload.opened_action? && !payload.pull_request_action?
-
-      log "Moving new issues to project"
-      ProjectManager.new(issue: payload.issue, project_column_id: config.project_column_id).run
+      if payload.opened_new_issue?
+        log "Moving new issues to project"
+        log ProjectManager.new(issue: payload.issue, project_column_id: config.project_column_id).run
+      end
     end
 
     def close_stale_issues

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -3,6 +3,7 @@ require "configuration"
 require "issue_closer"
 require "notifier"
 require "labeler"
+require "project_manager"
 require "notifications/recycle_notification"
 require "notifications/review_complete_notification"
 require "notifications/ready_for_review_notification"
@@ -24,6 +25,7 @@ class Processor
     notify_recycle
     notify_review
     add_labels
+    move_new_issue_to_project
     close_stale_issues
     logs.join("\n")
   end
@@ -69,6 +71,13 @@ class Processor
     def add_labels
       log "Updating labels"
       Labeler.new(payload.issue).run
+    end
+
+    def move_new_issue_to_project
+      return unless payload.opened_action?
+
+      log "Moving new issues to project"
+      ProjectManager.new(issue: payload.issue, project_column_id: config.project_column_id).run
     end
 
     def close_stale_issues

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -75,7 +75,7 @@ class Processor
 
     def move_new_issue_to_project
       if payload.opened_new_issue?
-        log "Moving new issues to project"
+        log "Adding card for new issue in configured project column"
         log ProjectManager.new(issue: payload.issue, project_column_id: config.project_column_id).run
       end
     end

--- a/lib/project_manager.rb
+++ b/lib/project_manager.rb
@@ -15,7 +15,11 @@ class ProjectManager
     attr_reader :issue, :project_column_id
 
     def belongs_to_project?
-      github.column_cards(project_column_id).map(&:content_url).include?(issue.html_url)
+      begin
+        github.column_cards(project_column_id).map(&:content_url).include?(issue.html_url)
+      rescue  Octokit::NotFound, Octokit::Unauthorized
+        {}
+      end
     end
 
     def add_to_project

--- a/lib/project_manager.rb
+++ b/lib/project_manager.rb
@@ -15,7 +15,7 @@ class ProjectManager
     attr_reader :issue, :project_column_id
 
     def add_to_project
-      github.create_project_card(project_column_id, content_id: issue.number, content_type: "Issue")
+      github.create_project_card(project_column_id, content_id: issue.id, content_type: "Issue")
       "Card created."
     rescue Octokit::NotFound
       "Could not find column with id #{project_column_id}."

--- a/lib/project_manager.rb
+++ b/lib/project_manager.rb
@@ -5,8 +5,8 @@ class ProjectManager
   end
 
   def run
-    return unless project_column_id && !belongs_to_project?
-    
+    return "project manager not configured, skipping." if project_column_id.blank?
+
     add_to_project
   end
 
@@ -14,20 +14,16 @@ class ProjectManager
 
     attr_reader :issue, :project_column_id
 
-    def belongs_to_project?
-      begin
-        github.column_cards(project_column_id).map(&:content_url).include?(issue.html_url)
-      rescue  Octokit::NotFound, Octokit::Unauthorized
-        {}
-      end
-    end
-
     def add_to_project
-      github.create_project_card(project_column_id, content_id: issue.number, content_type: 'Issue')
+      github.create_project_card(project_column_id, content_id: issue.number, content_type: "Issue")
+      "card created."
+    rescue Octokit::NotFound
+      "could not find column with id #{project_column_id}"
+    rescue Octokit::Unauthorized
+      "could not find column with id #{project_column_id} in this project"
     end
 
     def github
       Cp8.github_client
     end
-
 end

--- a/lib/project_manager.rb
+++ b/lib/project_manager.rb
@@ -5,7 +5,7 @@ class ProjectManager
   end
 
   def run
-    return "project manager not configured, skipping." if project_column_id.blank?
+    return "Project manager not configured, skipping." if project_column_id.blank?
 
     add_to_project
   end
@@ -16,11 +16,11 @@ class ProjectManager
 
     def add_to_project
       github.create_project_card(project_column_id, content_id: issue.number, content_type: "Issue")
-      "card created."
+      "Card created."
     rescue Octokit::NotFound
-      "could not find column with id #{project_column_id}"
+      "Could not find column with id #{project_column_id}."
     rescue Octokit::Unauthorized
-      "could not find column with id #{project_column_id} in this project"
+      "Could not find column with id #{project_column_id} in this project."
     end
 
     def github

--- a/lib/project_manager.rb
+++ b/lib/project_manager.rb
@@ -5,7 +5,7 @@ class ProjectManager
   end
 
   def run
-    return "Project manager not configured, skipping." if project_column_id.blank?
+    return "project_column_id not configured, skipping." if project_column_id.blank?
 
     add_to_project
   end
@@ -16,7 +16,7 @@ class ProjectManager
 
     def add_to_project
       github.create_project_card(project_column_id, content_id: issue.id, content_type: "Issue")
-      "Card created"
+      "Card added"
     rescue Octokit::NotFound
       "Could not find column with id #{project_column_id}"
     rescue Octokit::Unauthorized

--- a/lib/project_manager.rb
+++ b/lib/project_manager.rb
@@ -1,0 +1,29 @@
+class ProjectManager
+  def initialize(issue:, project_column_id: nil)
+    @issue = issue
+    @project_column_id = project_column_id
+  end
+
+  def run
+    return unless project_column_id && !belongs_to_project?
+    
+    add_to_project
+  end
+
+  private
+
+    attr_reader :issue, :project_column_id
+
+    def belongs_to_project?
+      github.column_cards(project_column_id).map(&:content_url).include?(issue.html_url)
+    end
+
+    def add_to_project
+      github.create_project_card(project_column_id, content_id: issue.number, content_type: 'Issue')
+    end
+
+    def github
+      Cp8.github_client
+    end
+
+end

--- a/lib/project_manager.rb
+++ b/lib/project_manager.rb
@@ -16,11 +16,11 @@ class ProjectManager
 
     def add_to_project
       github.create_project_card(project_column_id, content_id: issue.id, content_type: "Issue")
-      "Card created."
+      "Card created"
     rescue Octokit::NotFound
-      "Could not find column with id #{project_column_id}."
+      "Could not find column with id #{project_column_id}"
     rescue Octokit::Unauthorized
-      "Could not find column with id #{project_column_id} in this project."
+      "Could not find column with id #{project_column_id} in this project"
     end
 
     def github

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -22,7 +22,7 @@ class ProcessorTest < Minitest::Test
   end
 
   def test_closing_stale_prs
-    github.expects(:search_issues).with("repo:balvig/cp-8 is:open updated:<1969-12-04T00:00:00+00:00").once.returns(stub(items: [{ number: 1 }]))
+    github.expects(:search_issues).with("repo:balvig/cp-8 is:open updated:<1969-12-04T00:00:00+00:00").once.returns(stub(items: [{ number: 1, id: 1 }]))
     github.expects(:add_comment)
     github.expects(:close_issue).with("balvig/cp-8", 1)
     github.expects(:add_labels_to_an_issue).with("balvig/cp-8", 1, [:Icebox]).once
@@ -68,7 +68,7 @@ class ProcessorTest < Minitest::Test
   end
 
   def test_adding_new_issues_to_project
-    github.expects(:create_project_card).with(49, content_id: 2, content_type: "Issue"). once
+    github.expects(:create_project_card).with(49, content_id: 137013866, content_type: "Issue"). once
 
     process_payload(:issue_wip, config: { project_column_id: PROJECT_COLUMN_ID } )
   end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -66,6 +66,13 @@ class ProcessorTest < Minitest::Test
     process_payload(:pull_request_added_wip)
   end
 
+  def test_adding_new_issues_to_project
+    github.expects(:column_cards).once.returns([stub(content_url: "https://api.github.com/repos/api-playground/projects-test/issues/3")])
+    github.expects(:create_project_card).once
+
+    process_payload(:issue_wip, config: { review_channel: "#reviews", project_column_id: 49 } )
+  end
+
   def test_not_adding_labels_to_plain_issues
     github.expects(:add_labels_to_an_issue).never
 
@@ -138,15 +145,15 @@ class ProcessorTest < Minitest::Test
 
   private
 
-    def process_payload(file)
-      process create_payload(file)
+    def process_payload(file, config: default_config)
+      process(create_payload(file), config: config)
     end
 
-    def process(payload)
+    def process(payload, config: default_config)
       Processor.new(payload, config: config).process
     end
 
-    def config
+    def default_config
       { review_channel: "#reviews" }
     end
 

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class ProcessorTest < Minitest::Test
   CP8_USER_ID = 9999
+  PROJECT_COLUMN_ID = 49
 
   class TestChatClient
     cattr_accessor :deliveries do
@@ -67,24 +68,21 @@ class ProcessorTest < Minitest::Test
   end
 
   def test_adding_new_issues_to_project
-    github.expects(:column_cards).once.returns([stub(content_url: "https://api.github.com/repos/api-playground/projects-test/issues/3")])
-    github.expects(:create_project_card).once
+    github.expects(:create_project_card).with(49, content_id: 2, content_type: "Issue"). once
 
-    process_payload(:issue_wip, config: { review_channel: "#reviews", project_column_id: 49 } )
+    process_payload(:issue_wip, config: { project_column_id: PROJECT_COLUMN_ID } )
   end
 
-  def test_not_adding_new_issues_to_project_if_column_not_in_project
-    github.expects(:column_cards).once.raises(Octokit::NotFound)
-    github.expects(:create_project_card).never
+  def test_adding_new_issues_to_project_if_column_not_in_project
+    github.expects(:create_project_card).raises(Octokit::NotFound)
 
-    process_payload(:issue_wip, config: { review_channel: "#reviews", project_column_id: 49 } )
+    process_payload(:issue_wip, config: { project_column_id: PROJECT_COLUMN_ID } )
   end
 
   def test_not_adding_new_pr_to_project
-    github.expects(:column_cards).never
     github.expects(:create_project_card).never
 
-    process_payload(:pull_request, config: { review_channel: "#reviews", project_column_id: 49 } )
+    process_payload(:pull_request, config: { project_column_id: PROJECT_COLUMN_ID } )
   end
 
   def test_not_adding_labels_to_plain_issues

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -73,6 +73,20 @@ class ProcessorTest < Minitest::Test
     process_payload(:issue_wip, config: { review_channel: "#reviews", project_column_id: 49 } )
   end
 
+  def test_not_adding_new_issues_to_project_if_column_not_in_project
+    github.expects(:column_cards).once.raises(Octokit::NotFound)
+    github.expects(:create_project_card).never
+
+    process_payload(:issue_wip, config: { review_channel: "#reviews", project_column_id: 49 } )
+  end
+
+  def test_not_adding_new_pr_to_project
+    github.expects(:column_cards).never
+    github.expects(:create_project_card).never
+
+    process_payload(:pull_request, config: { review_channel: "#reviews", project_column_id: 49 } )
+  end
+
   def test_not_adding_labels_to_plain_issues
     github.expects(:add_labels_to_an_issue).never
 


### PR DESCRIPTION
This PR contains the implementation of a feature requested here: https://github.com/cookpad/cp8/issues/40

When enabled, cp8 will move newly created issues to a predefined column in one of the repository projects.

Project column has to be defined in the payload like so:
`/payload?config[project_column_id]=49 # Move newly created issues to this project column`

Without the defined `project_column_id` cp8 this feature will be disabled.
