### PR TITLE
require yaml

### DIFF
--- a/lib/user.rb
+++ b/lib/user.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 class User
   BOT_LOGINS = %w(houndci-bot)
   MAPPINGS = YAML::load_file(File.join(__dir__, "user_mappings.yml"))


### PR DESCRIPTION
After bumping Puma to 3.12.0, it seems we need to explicitly require "yaml".

```
2018-08-21T11:04:06.543270+00:00 app[web.1]: Puma starting in single mode...
2018-08-21T11:04:06.543291+00:00 app[web.1]: * Version 3.12.0 (ruby 2.4.2-p198), codename: Llamas in Pajamas
2018-08-21T11:04:06.543292+00:00 app[web.1]: * Min threads: 5, max threads: 5
2018-08-21T11:04:06.543294+00:00 app[web.1]: * Environment: production
2018-08-21T11:04:07.321628+00:00 app[web.1]: ! Unable to load application: NameError: uninitialized constant User::YAML
2018-08-21T11:04:07.321840+00:00 app[web.1]: bundler: failed to load command: puma (/app/vendor/bundle/ruby/2.4.0/bin/puma)
2018-08-21T11:04:07.321965+00:00 app[web.1]: NameError: uninitialized constant User::YAML
2018-08-21T11:04:07.321967+00:00 app[web.1]: /app/lib/user.rb:3:in `<class:User>'
2018-08-21T11:04:07.321969+00:00 app[web.1]: /app/lib/user.rb:1:in `<top (required)>'
2018-08-21T11:04:07.321971+00:00 app[web.1]: /app/lib/issue.rb:2:in `require'
2018-08-21T11:04:07.321972+00:00 app[web.1]: /app/lib/issue.rb:2:in `<top (required)>'
2018-08-21T11:04:07.321974+00:00 app[web.1]: /app/lib/payload.rb:4:in `require'
2018-08-21T11:04:07.321975+00:00 app[web.1]: /app/lib/payload.rb:4:in `<top (required)>'
2018-08-21T11:04:07.321977+00:00 app[web.1]: /app/lib/cp8.rb:2:in `require'
2018-08-21T11:04:07.321978+00:00 app[web.1]: /app/lib/cp8.rb:2:in `<top (required)>'
2018-08-21T11:04:07.321981+00:00 app[web.1]: /app/app.rb:8:in `require'
2018-08-21T11:04:07.321982+00:00 app[web.1]: /app/app.rb:8:in `<top (required)>'
```

With Puma 3.0.2 the error doesn't happen.