### PR TITLE
Bring back project manager feature :D

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ CP-8 can:
   - a WIP PR is "un-WIPped"
   - a `:recycle:` comment is posted
   - a PR is approved/has changes requested
+- Automatically add new issues to projects
 - Move issues to other repos using labels
 
 ## Setup
@@ -35,5 +36,6 @@ Add `.cp8.yml` file to root of project, and turn on features by configuring them
 ```yml
 stale_issue_weeks: 4 # Set stale issue cutoff to 4 weeks
 review_channel: reviews # Send review requests/updates to specified Slack channel
+project_column_id: 49 # Automatically add new issues to a project column
 move_to_prefix:  move-to # Move issue to other repo when labeled with prefix, ie `move-to:cookpad/cp8`
 ```

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,9 +1,10 @@
 class Configuration
-  attr_reader :stale_issue_weeks, :review_channel, :move_to_prefix
+  attr_reader :stale_issue_weeks, :review_channel, :project_column_id, :move_to_prefix
 
-  def initialize(stale_issue_weeks: nil, review_channel: nil, move_to_prefix: nil)
+  def initialize(stale_issue_weeks: nil, review_channel: nil, project_column_id: nil, move_to_prefix: nil)
     @stale_issue_weeks = stale_issue_weeks
     @review_channel = review_channel
+    @project_column_id = project_column_id
     @move_to_prefix = move_to_prefix
   end
 end

--- a/lib/payload.rb
+++ b/lib/payload.rb
@@ -42,6 +42,14 @@ class Payload
     action.submitted? && review&.decisive?
   end
 
+  def opened_new_issue?
+    action.opened? && issue_action?
+  end
+
+  def issue_action?
+    !pull_request_action?
+  end
+
   def pull_request_action?
     data[:pull_request].present?
   end

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -4,6 +4,7 @@ require "issue_closer"
 require "issue_delegator"
 require "notifier"
 require "labeler"
+require "project_manager"
 require "notifications/recycle_notification"
 require "notifications/review_complete_notification"
 require "notifications/ready_for_review_notification"
@@ -25,6 +26,7 @@ class Processor
     notify_recycle
     notify_review
     add_labels
+    move_new_issue_to_project
     delegate_issue
     close_stale_issues
     logs.join("\n")
@@ -71,6 +73,13 @@ class Processor
     def add_labels
       log "Updating labels"
       Labeler.new(payload.issue).run
+    end
+
+    def move_new_issue_to_project
+      if payload.opened_new_issue?
+        log "Adding card for new issue in configured project column"
+        log ProjectManager.new(issue: payload.issue, project_column_id: config.project_column_id).run
+      end
     end
 
     def delegate_issue

--- a/lib/project_manager.rb
+++ b/lib/project_manager.rb
@@ -1,0 +1,29 @@
+class ProjectManager
+  def initialize(issue:, project_column_id: nil)
+    @issue = issue
+    @project_column_id = project_column_id
+  end
+
+  def run
+    return "project_column_id not configured, skipping." if project_column_id.blank?
+
+    add_to_project
+  end
+
+  private
+
+    attr_reader :issue, :project_column_id
+
+    def add_to_project
+      github.create_project_card(project_column_id, content_id: issue.id, content_type: "Issue")
+      "Card added"
+    rescue Octokit::NotFound
+      "Could not find column with id #{project_column_id}"
+    rescue Octokit::Unauthorized
+      "Could not find column with id #{project_column_id} in this project"
+    end
+
+    def github
+      Cp8.github_client
+    end
+end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ProcessorTest < Minitest::Test
+  PROJECT_COLUMN_ID = 49
+
   class TestChatClient
     cattr_accessor :deliveries do
       []
@@ -68,6 +70,24 @@ class ProcessorTest < Minitest::Test
     github.expects(:add_labels_to_an_issue).with("balvig/cp-8", 1, [:WIP]).once
 
     process_payload(:pull_request_added_wip)
+  end
+
+  def test_adding_new_issues_to_project
+    github.expects(:create_project_card).with(49, content_id: 137013866, content_type: "Issue"). once
+
+    process_payload(:issue_wip, config: { project_column_id: PROJECT_COLUMN_ID } )
+  end
+
+  def test_adding_new_issues_to_project_if_column_not_in_project
+    github.expects(:create_project_card).raises(Octokit::NotFound)
+
+    process_payload(:issue_wip, config: { project_column_id: PROJECT_COLUMN_ID } )
+  end
+
+  def test_not_adding_new_pr_to_project
+    github.expects(:create_project_card).never
+
+    process_payload(:pull_request, config: { project_column_id: PROJECT_COLUMN_ID } )
   end
 
   def test_not_adding_labels_to_plain_issues


### PR DESCRIPTION
As our [past selves already knew](https://github.com/cookpad/cp8/issues/40#issuecomment-395243072), but our current selves foolishly forgot, the GitHub automation feature actually only works if you _manually_ add an issue to a project first, and what this feature does is automatically add _any_ new issue to a project board column.

cc @pauchan 