### PR TITLE
show a more helpful error message when things go wrong

### DIFF
--- a/lib/issue_delegator.rb
+++ b/lib/issue_delegator.rb
@@ -9,8 +9,7 @@ class IssueDelegator
     return if prefix.blank?
 
     if label.prefix == prefix
-      create_copy_of_issue_in_selected_repo
-      close_original_issue
+      move_issue
     end
   end
 
@@ -18,12 +17,23 @@ class IssueDelegator
 
     attr_reader :label, :issue, :prefix
 
+    def move_issue
+      create_copy_of_issue_in_selected_repo
+      close_original_issue
+    rescue Octokit::NotFound
+      post_error_comment
+    end
+
     def create_copy_of_issue_in_selected_repo
-      github.create_issue(label.suffix, issue.title, moved_issue_body)
+      github.create_issue(target_repo, issue.title, moved_issue_body)
     end
 
     def close_original_issue
       github.close_issue(issue.repo, issue.number)
+    end
+
+    def target_repo
+      label.suffix
     end
 
     def github
@@ -36,5 +46,19 @@ class IssueDelegator
 
     def link_to_original_issue
       "_Moved from #{issue.html_url} (cc @#{issue.user.login})_\n\n---\n"
+    end
+
+    def post_error_comment
+      github.add_comment(issue.repo, issue.number, error_message)
+    end
+
+    def error_message
+      <<~TEXT
+        [BOOooop...] I tried to move this issue to #{target_repo}, but couldn't.
+
+        Maybe I don't have the right permissions?
+
+        Try adding me to that repo and try again!
+      TEXT
     end
 end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -174,6 +174,13 @@ class ProcessorTest < Minitest::Test
     process_payload(:move_to_label, config: { move_to_prefix: "move-to" } )
   end
 
+  def test_moving_issues_to_repo_without_permissions
+    github.expects(:create_issue).once.raises(Octokit::NotFound)
+    github.expects(:add_comment)
+
+    process_payload(:move_to_label, config: { move_to_prefix: "move-to" } )
+  end
+
   private
 
     def process_payload(file, config: default_config)


### PR DESCRIPTION
`move-to` feature will require CP8 to have permissions to the target repo, but when it doesn't it just fails silently.

This makes CP8 post back that something went wrong 😅 