### PR TITLE
Link to cp8_cli in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ move_to_prefix:  move-to # Move issue to other repo when labeled with prefix, ie
 
 ## CLI
 
-At Cookpad, we use **cp8_cli** to create PRs, open the PR of the local branch in the browser and for similar tasks. Please find our example implementation under https://github.com/cookpad/cp8_cli and take some inspiration from it.
+CP8 has a [CLI counterpart](https://github.com/cookpad/cp8_cli), that while not required, provides some extra convenience for GitHub-driven projects in addition to what the bot offers.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ review_channel: reviews # Send review requests/updates to specified Slack channe
 project_column_id: 49 # Automatically add new issues to a project column
 move_to_prefix:  move-to # Move issue to other repo when labeled with prefix, ie `move-to:cookpad/cp8`
 ```
+
+## CLI
+
+At Cookpad, we use **cp8_cli** to create PRs, open the PR of the local branch in the browser and for similar tasks. Please find our example implementation under https://github.com/cookpad/cp8_cli and take some inspiration from it.


### PR DESCRIPTION
The CLI should be linked in the README to make it easier for developers to see how the tools can work together to further automize workflows.

It might also help our new Cookpad employees (like me!) to find the right gem to install after updating the Ruby version and wondering why `cp8 command` does no longer work ;-)