### PR TITLE
Print out repository name in Slack message

### DIFF
--- a/lib/notifications/review_complete_notification.rb
+++ b/lib/notifications/review_complete_notification.rb
@@ -7,12 +7,16 @@ class ReviewCompleteNotification < Notification
   end
 
   def text
-    ":#{icon}: <#{link}|##{issue.number} #{action}> by #{review.user.login} _(cc #{issue.user.chat_name})_"
+    ":#{icon}: #{repo_name}<#{link}|##{issue.number} #{action}> by #{review.user.login} _(cc #{issue.user.chat_name})_"
   end
 
   private
 
     attr_reader :review, :issue
+
+    def repo_name
+      review.repository_name
+    end
 
     def link
       review.html_url

--- a/lib/review.rb
+++ b/lib/review.rb
@@ -23,6 +23,10 @@ class Review
     User.from_resource(user_resource)
   end
 
+  def repository_name
+    @_repository_name ||= html_url.split("/")[4]
+  end
+
   private
 
     attr_reader :state, :user_resource

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -166,13 +166,13 @@ class ProcessorTest < Minitest::Test
   def test_notifying_requested_changes
     process_payload(:changes_requested)
 
-    assert_equal ":x: <https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 changes required> by reviewer _(cc <@submitter>)_", last_notification[:text]
+    assert_equal ":x: cp-8<https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 changes required> by reviewer _(cc <@submitter>)_", last_notification[:text]
   end
 
   def test_notifying_approval
     process_payload(:approval)
 
-    assert_equal ":white_check_mark: <https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 was approved> by reviewer _(cc <@submitter>)_", last_notification[:text]
+    assert_equal ":white_check_mark: cp-8<https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 was approved> by reviewer _(cc <@submitter>)_", last_notification[:text]
   end
 
   private


### PR DESCRIPTION
Currently, we configure cp-8 so that both global-web and global-feeds reviews are posting to #reviews channel.

This brings a bit of confusion sometimes when multiple repositories has review completion notification next to each other:

![image](https://user-images.githubusercontent.com/4912/51976742-d9f0b200-24c8-11e9-880f-d6784e70dd43.png)

I'd like to propose this patch to just print out the repository name, so it would say `global-web#1234` in the Slack message.