### PR TITLE
Show repo for review requests

### DIFF
--- a/lib/notifications/review_request_notification.rb
+++ b/lib/notifications/review_request_notification.rb
@@ -37,7 +37,7 @@ class ReviewRequestNotification < Notification
       {
         author_name: issue.user.login,
         author_icon: issue.user.avatar_url,
-        fields: [issue_field, changes_field]
+        fields: [issue_field, changes_field, repo_field]
       }
     end
 
@@ -53,6 +53,14 @@ class ReviewRequestNotification < Notification
       {
         title: "Diff",
         value: "+#{issue.additions} / -#{issue.deletions}",
+        short: true
+      }
+    end
+
+    def repo_field
+      {
+        title: "Repo",
+        value: issue.repo,
         short: true
       }
     end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -130,13 +130,19 @@ class ProcessorTest < Minitest::Test
     assert_equal ":mag: New PR", last_notification[:text]
   end
 
+  def test_repo_shown_in_attachment
+    process_payload(:pull_request)
+
+    assert_equal "balvig/cp-8", last_notification_attachment[:fields].last[:value]
+  end
+
   def test_notifying_new_small_pull_requests_without_mention
     github.stubs(:pull_request).returns(additions: 5, deletions: 5)
     process_payload(:pull_request)
 
     assert_equal ":mag: Small PR", last_notification[:text]
     assert_equal ":mag: Small PR", last_notification[:fallback]
-    assert_equal "+5 / -5", last_notification_attachment[:fields].last[:value]
+    assert_equal "+5 / -5", last_notification_attachment[:fields].second[:value]
   end
 
   def test_notifying_pull_requests_with_requested_reviewers


### PR DESCRIPTION
Closes #72.

Alternative to #72, this shows the repo name as one of the "attachments", and only for request message (ie "approved/changes requested" don't show them, as it seems unnecessary for that stage):

<img width="366" alt="screen shot 2019-02-15 at 14 24 39" src="https://user-images.githubusercontent.com/104138/52836445-dc404680-312d-11e9-9a31-600b1ddc58ce.png">

cc @sikachu 