### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ project_column_id: 49 # Automatically add new issues to a project column
 Your GitHub username needs to be mapped to your Slack ID in order for CP8 to mention you:
 
 - Copy your Slack ID from your account settings
-- Submit a PR to this repo to add `[github_name]:[slack_id]` to `/lib/user_mappings.yml`. See, for example, [this PR](https://github.com/cookpad/cp8/pull/68))
+- Submit a PR to this repo to add `[github_name]: [slack_id]` to `/lib/user_mappings.yml`. See, for example, [this PR](https://github.com/cookpad/cp8/pull/68))
 
 ## CLI
 


### PR DESCRIPTION
Guide for adding Github username need to have space after semicolon otherwise YAML wouldn't be able to parse it properly.