### PR TITLE
soften tone of changes_requested notification

### DIFF
--- a/lib/notifications/review_complete_notification.rb
+++ b/lib/notifications/review_complete_notification.rb
@@ -30,7 +30,7 @@ class ReviewCompleteNotification < Notification
       if review.approved?
         "was approved"
       else
-        "changes suggested"
+        "changes requested"
       end
     end
 end

--- a/lib/notifications/review_complete_notification.rb
+++ b/lib/notifications/review_complete_notification.rb
@@ -22,7 +22,7 @@ class ReviewCompleteNotification < Notification
       if review.approved?
         :white_check_mark
       else
-        :x
+        :speech_balloon
       end
     end
 
@@ -30,7 +30,7 @@ class ReviewCompleteNotification < Notification
       if review.approved?
         "was approved"
       else
-        "changes required"
+        "changes suggested"
       end
     end
 end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -172,7 +172,7 @@ class ProcessorTest < Minitest::Test
   def test_notifying_requested_changes
     process_payload(:changes_requested)
 
-    assert_equal ":x: <https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 changes required> by reviewer _(cc <@submitter>)_", last_notification[:text]
+    assert_equal ":speech_balloon: <https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 changes suggested> by reviewer _(cc <@submitter>)_", last_notification[:text]
   end
 
   def test_notifying_approval

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -172,7 +172,7 @@ class ProcessorTest < Minitest::Test
   def test_notifying_requested_changes
     process_payload(:changes_requested)
 
-    assert_equal ":speech_balloon: <https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 changes suggested> by reviewer _(cc <@submitter>)_", last_notification[:text]
+    assert_equal ":speech_balloon: <https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 changes requested> by reviewer _(cc <@submitter>)_", last_notification[:text]
   end
 
   def test_notifying_approval


### PR DESCRIPTION
## Background

In our handbook, when reviewing we encourage [picking _either approve or request changes_](https://github.com/cookpad/web-chapter/blob/master/handbook/practices/code-review.md#reviewing):

> Choose either "request changes" or "approve" so the author knows how to proceed.

I _think_ the reasoning is fairly solid: a PR submitter needs to understand where they're at after a review.

The GitHub UI at the time of writing defines it as such:

- **Approve:** Submit feedback and approve merging these changes.
- **Request changes:** Submit feedback that must be addressed before merging.
- **Comment:** Submit general feedback without explicit approval.

So while first two are really clear, what should you do when given "general feedback"? 😅 

- How strongly does the reviewer feel about the comment?
- Once addressed, do you need another review? 
- If so, how is it then different from "request changes"? If not, why isn't it an approval?

Even then, while I do think the logic holds water, I don't deny a certain psychological barrier to picking "Request changes", which (although they've softened the message over the years) is exacerbated a little by the GitHub UI:

<img width="318" alt="Screen Shot 2019-05-30 at 11 07 18" src="https://user-images.githubusercontent.com/104138/58603282-1db6c500-82cb-11e9-99b1-d245f7a4db02.png">

or, when read through the filter of the internet: "BALVIG IS REQUESTING THAT YOU MAKE THESE CHANGES! YOU CAN TELL HE IS SERIOUS ABOUT IT BECAUSE RED ICON!"  

## This PR

So...while I realize that trying to mentally re-interpret what the UI suggests is maybe ultimately a futile endeavour and I wish GitHub would remove the 3rd "general feedback" option from the review feature, what we _can_ at least do is soften our own CP-8 messaging:

### Before

<img width="426" alt="Screen Shot 2019-05-30 at 10 46 34" src="https://user-images.githubusercontent.com/104138/58603617-68850c80-82cc-11e9-9bf3-ffc96a559cc9.png">


### After

<img width="446" alt="Screen Shot 2019-05-30 at 10 53 57" src="https://user-images.githubusercontent.com/104138/58603607-60c56800-82cc-11e9-8630-cd230ae35d33.png">
