### PR TITLE
According to the Slack docs we need to escape <>& chars

### DIFF
--- a/lib/issue_title.rb
+++ b/lib/issue_title.rb
@@ -4,10 +4,20 @@ class IssueTitle < SimpleDelegator
     "Blocker" => :blocker
   }
 
+  ESCAPED_CHARACTERS = {
+    "<" => "&lt;",
+    ">" => "&gt;",
+    "&" => "&amp;"
+  }.freeze
+
   def tags
     raw_tags.map do |tag|
       VALID_TAGS[tag]
     end.compact
+  end
+
+  def to_s
+    self.gsub(/[#{ESCAPED_CHARACTERS.keys.join}]/, ESCAPED_CHARACTERS)
   end
 
   private

--- a/test/issue_title_test.rb
+++ b/test/issue_title_test.rb
@@ -6,4 +6,10 @@ class IssueTitleTest < Minitest::Test
 
     assert_equal [:wip], title.tags
   end
+
+  def test_title_escaping
+    title = IssueTitle.new("With <div>HTML</div> & ampersamp")
+
+    assert_equal title.to_s, "With &lt;div&gt;HTML&lt;/div&gt; &amp; ampersamp"
+  end
 end

--- a/test/issue_title_test.rb
+++ b/test/issue_title_test.rb
@@ -10,6 +10,6 @@ class IssueTitleTest < Minitest::Test
   def test_title_escaping
     title = IssueTitle.new("With <div>HTML</div> & ampersand")
 
-    assert_equal title.to_s, "With &lt;div&gt;HTML&lt;/div&gt; &amp; ampersamp"
+    assert_equal title.to_s, "With &lt;div&gt;HTML&lt;/div&gt; &amp; ampersand"
   end
 end

--- a/test/issue_title_test.rb
+++ b/test/issue_title_test.rb
@@ -8,7 +8,7 @@ class IssueTitleTest < Minitest::Test
   end
 
   def test_title_escaping
-    title = IssueTitle.new("With <div>HTML</div> & ampersamp")
+    title = IssueTitle.new("With <div>HTML</div> & ampersand")
 
     assert_equal title.to_s, "With &lt;div&gt;HTML&lt;/div&gt; &amp; ampersamp"
   end


### PR DESCRIPTION
https://api.slack.com/docs/message-formatting

See e.g. https://ckpd.slack.com/archives/C8GQ6ND3P/p1559201762001000