### PR TITLE
Add alinagrishchuk to user mappings

### DIFF
--- a/lib/user_mappings.yml
+++ b/lib/user_mappings.yml
@@ -1,4 +1,5 @@
 aadityataparia: W8VTGQ3V1
+alinagrishchuk: W011WNXS19T
 andrassy: WDSR0CYV7
 ainame: U5U7GQ89X
 aqeelvn: W8W0LGM0C


### PR DESCRIPTION
I noticed in the [#review](https://ckpd.slack.com/archives/C8GQ6ND3P/p1588181595126500) channel that alinagrishchuk wasn't mapped to the slack account