### PR TITLE
Proper buddy sytem issue link

### DIFF
--- a/lib/buddy_mention.rb
+++ b/lib/buddy_mention.rb
@@ -30,7 +30,7 @@ class BuddyMention
       <<~TEXT
       **[Try-out]**
 
-      @#{buddy.login} is your buddy as part of the [Buddy System](https://github.com/cookpad/web-chapter/issues/411) try-out and has been added as a reviewer.
+      @#{buddy.login} is your buddy as part of the [Buddy System](https://github.com/cookpad/web-chapter/issues/410) try-out and has been added as a reviewer.
       TEXT
     end
 


### PR DESCRIPTION
In https://github.com/cookpad/cp8/commit/d2c580cc7629d3e8521ddd54de585922d5a61927 buddy system issue link was set to flaky spec [issue](https://github.com/cookpad/web-chapter/issues/411), looks like it was not intended change. This PR sets it back 😉 