### PR TITLE
Names in buddy_mappings.yml must be lowercase

### DIFF
--- a/lib/buddy_mappings.yml
+++ b/lib/buddy_mappings.yml
@@ -12,5 +12,5 @@
   - tejanium
 - - aqeelvn
   - ollieh-m
-- - Knack
+- - knack
   - dannyd4315


### PR DESCRIPTION
I was being assigned to @dannyd4315's PR but he wasn't being assigned to mine. After some debugging, I found that the login names in this YML file must be lowercased, even if my Github username is capitalized.

This is a quick fix for my username. Alternatively, we could fix the BuddyResolver class to be case-insensitive