### PR TITLE
send notifications for reviews that aren't explicit approval

### DIFF
--- a/lib/notifications/review_complete_notification.rb
+++ b/lib/notifications/review_complete_notification.rb
@@ -30,7 +30,7 @@ class ReviewCompleteNotification < Notification
       if review.approved?
         "was approved"
       else
-        "changes requested"
+        "reviewed"
       end
     end
 end

--- a/lib/payload.rb
+++ b/lib/payload.rb
@@ -44,7 +44,7 @@ class Payload
   end
 
   def review_action?
-    action.submitted? && review&.decisive?
+    action.submitted? && review
   end
 
   def opened_new_issue?

--- a/lib/review.rb
+++ b/lib/review.rb
@@ -11,14 +11,6 @@ class Review
     state == "approved"
   end
 
-  def changes_requested?
-    state == "changes_requested"
-  end
-
-  def decisive?
-    approved? || changes_requested?
-  end
-
   def user
     User.from_resource(user_resource)
   end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -202,7 +202,7 @@ class ProcessorTest < Minitest::Test
   def test_notifying_requested_changes
     process_payload(:changes_requested)
 
-    assert_equal ":speech_balloon: <https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 changes requested> by reviewer _(cc <@submitter>)_", last_notification[:text]
+    assert_equal ":speech_balloon: <https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 reviewed> by reviewer _(cc <@submitter>)_", last_notification[:text]
   end
 
   def test_notifying_approval


### PR DESCRIPTION
The behavior that suppresses notification for reviews which neither approve nor request changes was added hand in hand with the guideline in https://github.com/cookpad/web-chapter/blob/master/handbook/sections/code-review.md#reviewing:

> Choose either "request changes" or "approve" so the author knows how to proceed.

Being clear about how strongly we feel about comments in a review is still crucial, but somehow I still find situations where the choice between approve/request changes is difficult.

For example, [if I need to ask more questions first](https://github.com/cookpad/global-web/pull/20938#pullrequestreview-495267545), it's not an approval, but it's not really "REQUEST CHANGES" either. 🤔 

For those cases, I believe it will tighten the review loop if a submitter is notified early on via the `#reviews` channel.

Therefore, while it shouldn't be taken as an invitation to indecisiveness in reviews 😅 , I believe
enabling notifications for the "Submit general feedback without explicit approval" choice will ultimately be helpful.