### PR TITLE
don't send notifications for submitter comments

### DIFF
--- a/lib/payload.rb
+++ b/lib/payload.rb
@@ -47,6 +47,10 @@ class Payload
     action.submitted? && review
   end
 
+  def submitter_action?
+    issue.user == sender
+  end
+
   def opened_new_issue?
     action.opened? && issue_action?
   end
@@ -111,5 +115,9 @@ class Payload
 
     def dismissed_review?
       action == "dismissed"
+    end
+
+    def sender
+      User.new(data[:sender])
     end
 end

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -88,6 +88,7 @@ class Processor
     end
 
     def notify_review
+      return if payload.submitter_action?
       return unless payload.review_action?
 
       log "Notifying review"

--- a/test/fixtures/submitter_review.json
+++ b/test/fixtures/submitter_review.json
@@ -1,0 +1,30 @@
+{
+  "action": "submitted",
+  "review": {
+    "id": 85607834,
+    "user": {
+      "login": "submitter",
+      "id": 4912
+    },
+    "state": "commented",
+    "html_url": "https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834"
+  },
+  "pull_request": {
+    "id": 158812981,
+    "number": 6561,
+    "title": "Generate link with a correct region",
+    "user": {
+      "login": "submitter",
+      "id": 4912
+    }
+  },
+  "repository": {
+    "id": 21350067,
+    "name": "cp-8",
+    "full_name": "cookpad/cp-8"
+  },
+  "sender": {
+    "login": "submitter",
+    "id": 4912
+  }
+}

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -211,6 +211,12 @@ class ProcessorTest < Minitest::Test
     assert_equal ":white_check_mark: <https://github.com/cookpad/cp-8/pull/6561#pullrequestreview-85607834|#6561 was approved> by reviewer _(cc <@submitter>)_", last_notification[:text]
   end
 
+  def test_not_notifying_reviews_from_submitter
+    process_payload(:submitter_review)
+
+    assert_nil last_notification
+  end
+
   def test_assigning_buddy
     BuddyResolver.mappings = [["balvig", "knack"]]
     github.expects(:request_pull_request_review).with("balvig/cp-8", 1, reviewers: ["knack"])


### PR DESCRIPTION
Ref: https://ckpd.slack.com/archives/C06B9GD9D/p1601039123029000

GitHub treats any inline comments as "reviews", even if from the PR submitter themselves.

This PR disables those notifications for now. 

We can rely on a ♻️ comment, to notify reviewers once done making changes/answering questions.