### PR TITLE
tiny refactoring enabled by #119

### DIFF
--- a/lib/issue.rb
+++ b/lib/issue.rb
@@ -30,7 +30,7 @@ class Issue
   end
 
   def peer_reviewers
-    reviewers.without(user, *User.bots)
+    reviewers.reject(&:bot?)
   end
 
   def requested_reviewers

--- a/lib/payload.rb
+++ b/lib/payload.rb
@@ -28,7 +28,7 @@ class Payload
   end
 
   def sender_bot?
-    data[:sender][:type] == "Bot"
+    sender.bot?
   end
 
   def unwip_action?

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -2,23 +2,17 @@ require "yaml"
 require "buddy_resolver"
 
 class User
-  BOT_LOGINS = %w(houndci-bot cookpad-devel)
   MAPPINGS = YAML::load_file(File.join(__dir__, "user_mappings.yml")).transform_keys(&:downcase)
   attr_reader :login
-
-  def self.bots
-    BOT_LOGINS.map do |login|
-      new(login: login)
-    end
-  end
 
   def self.from_resource(resource)
     new(resource.to_h)
   end
 
-  def initialize(login:, avatar_url: nil, **other)
+  def initialize(login:, avatar_url: nil, type: "User", **other)
     @login = login.downcase
     @avatar_url = avatar_url
+    @type = type
   end
 
   def chat_name
@@ -27,6 +21,10 @@ class User
 
   def avatar_url(size: 16)
     @avatar_url + "&size=#{size}"
+  end
+
+  def bot?
+    type == "Bot"
   end
 
   def ==(other)
@@ -41,6 +39,8 @@ class User
   end
 
   private
+
+    attr_reader :type
 
     def mapped_login
       MAPPINGS[login] || login


### PR DESCRIPTION
GitHub API includes a `type` attribute with their users nowadays, so we can rely on that instead of keeping our own list of bots.