### PR TITLE
Buddy up with Haroon

### DIFF
--- a/lib/buddy_mappings.yml
+++ b/lib/buddy_mappings.yml
@@ -12,7 +12,7 @@
   - alinagrishchuk
 - - lollkebear
   - tejanium
-- - aqeelvn
+- - hahmed
   - ollieh-m
 - - Knack
   - dannyd4315


### PR DESCRIPTION
Aqeel is on paternity leave, and Haroon is currently buddy-less, so let's buddy up.