### PR TITLE
Disable mention_threshold

### DIFF
--- a/lib/notifications/ready_for_review_notification.rb
+++ b/lib/notifications/ready_for_review_notification.rb
@@ -34,6 +34,8 @@ class ReadyForReviewNotification < ReviewRequestNotification
     end
 
     def small_pr?
+      return true if mention_threshold.zero?
+
       issue.additions <= mention_threshold
     end
 end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -108,6 +108,16 @@ class ProcessorTest < Minitest::Test
     assert_equal ":mag: Small PR - <@reviewer> please", last_notification[:text]
   end
 
+  def test_notifying_new_large_pull_requests_with_mention_threshold_disabled
+    github.stubs(:pull_request).returns(additions: 150, deletions: 75)
+    github.expects(:pull_request_review_requests).with("balvig/cp-8", 1).once.returns(
+      stub(users: [{ login: "reviewer" }])
+    )
+    process_payload(:pull_request, config: { mention_threshold: 0, review_channel: "#notification-test" } )
+
+    assert_equal ":mag: Small PR - <@reviewer> please", last_notification[:text]
+  end
+
   def test_repo_shown_in_attachment
     process_payload(:pull_request)
 


### PR DESCRIPTION
## What

Disable mention_threshold

## Why 

There are some cases where there is no threshold limit for being notified, one recent example is the API documentation [try out repo](https://github.com/cookpad/global-open-api/blob/main/.cp8.yml)

## How

This PR disabled the threshold by setting `mention_threshold` to zero.

## Anything Else

Probably `mention_threshold` default could be 0/nil and disabling the threshold by default? 