### PR TITLE
Add search team members to slack mapping, remove Ben Howes

### DIFF
--- a/lib/user_mappings.yml
+++ b/lib/user_mappings.yml
@@ -2,6 +2,7 @@ aadityataparia: W8VTGQ3V1
 alinagrishchuk: W011WNXS19T
 andrassy: WDSR0CYV7
 ainame: U5U7GQ89X
+Apmats: U01K15NDHNY
 aqeelvn: W8W0LGM0C
 barbacas: W8VGC5U3A
 bitdivision: U01C47PJKQR
@@ -27,6 +28,7 @@ mbarta: W8VKBDRH7
 mshka: U0HNC5Q3E
 ollieh-m: WEH1S8VMW
 radeklat: WTJ7CC6TG
+rejasupotaro: W8VBA1D4G
 robertomiranda: WEU4YNDAB
 samjacobclift: U01D4V5KP0B
 samrjenkins: WTXBH9D9Q
@@ -36,3 +38,4 @@ tejanium: WHMG60P47
 teka23: U5A0BM20L
 tomoya55: W8W4GBHC5
 tony-rowan: U01BHKTJQDV
+umutseven92: WGST0PKDF

--- a/lib/user_mappings.yml
+++ b/lib/user_mappings.yml
@@ -4,7 +4,7 @@ andrassy: WDSR0CYV7
 ainame: U5U7GQ89X
 aqeelvn: W8W0LGM0C
 barbacas: W8VGC5U3A
-benhowes: W0132FKR99A
+bitdivision: U01C47PJKQR
 brunobrgs: WCQCQTXFX
 chrisbr: WFWHS2W1M
 cizoro: W8W62JW2W


### PR DESCRIPTION
Adding my mapping for slack. Ben Howes no longer works at Cookpad, have removed that mapping.

Also adds other missing search team members